### PR TITLE
use dapple_packages

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule ".dapple/packages/ds-auth"]
-	path = .dapple/packages/ds-auth
+	path = dapple_packages/ds-auth
 	url = https://github.com/nexusdev/ds-auth


### PR DESCRIPTION
dapple v0.8 uses .dapple/packages, but this doesn't work well with
dapple v0.7.x. switch to dapple_packages until 0.8 released.
